### PR TITLE
Spanish UI and orange-dark theme

### DIFF
--- a/app/[locale]/globals.css
+++ b/app/[locale]/globals.css
@@ -30,8 +30,8 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 0 0% 3.9%;
+    --background: 0 0% 0%;
+    --foreground: 0 0% 98%;
 
     --muted: 0 0% 96.1%;
     --muted-foreground: 0 0% 45.1%;
@@ -45,14 +45,14 @@
     --border: 0 0% 89.8%;
     --input: 0 0% 89.8%;
 
-    --primary: 0 0% 9%;
-    --primary-foreground: 0 0% 98%;
+    --primary: 39 100% 50%;
+    --primary-foreground: 0 0% 0%;
 
-    --secondary: 0 0% 96.1%;
-    --secondary-foreground: 0 0% 9%;
+    --secondary: 39 100% 50%;
+    --secondary-foreground: 0 0% 0%;
 
-    --accent: 0 0% 96.1%;
-    --accent-foreground: 0 0% 9%;
+    --accent: 39 100% 50%;
+    --accent-foreground: 0 0% 0%;
 
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
@@ -63,7 +63,7 @@
   }
 
   .dark {
-    --background: 0 0% 3.9%;
+    --background: 0 0% 0%;
     --foreground: 0 0% 98%;
 
     --muted: 0 0% 14.9%;
@@ -78,14 +78,14 @@
     --border: 0 0% 14.9%;
     --input: 0 0% 14.9%;
 
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
+    --primary: 39 100% 50%;
+    --primary-foreground: 0 0% 0%;
 
-    --secondary: 0 0% 14.9%;
-    --secondary-foreground: 0 0% 98%;
+    --secondary: 39 100% 50%;
+    --secondary-foreground: 0 0% 0%;
 
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
+    --accent: 39 100% 50%;
+    --accent-foreground: 0 0% 0%;
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 85.7% 97.3%;

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -87,7 +87,7 @@ export default async function RootLayout({
   const { t, resources } = await initTranslations(locale, i18nNamespaces)
 
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang={locale} suppressHydrationWarning>
       <body className={inter.className}>
         <Providers attribute="class" defaultTheme="dark">
           <TranslationsProvider

--- a/i18nConfig.js
+++ b/i18nConfig.js
@@ -1,5 +1,5 @@
 const i18nConfig = {
-  defaultLocale: "en",
+  defaultLocale: "es",
   locales: [
     "ar",
     "bn",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1,0 +1,4 @@
+{
+  "Ask anything. Type \"/\" for prompts, \"@\" for files, and \"#\" for tools.": "Pregunta cualquier cosa. Escribe \"/\" para prompts, \"@\" para archivos y \"#\" para herramientas.",
+  "Quick Settings": "Ajustes Rápidos"
+}


### PR DESCRIPTION
## Summary
- set Spanish as the default locale
- add Spanish translations
- update html language attribute
- switch theme colors to black with orange accents

## Testing
- `npm test` *(fails: Cannot find module '@playwright/test', OpenAPI parsing fails)*

------
https://chatgpt.com/codex/tasks/task_e_68704c924198832f943ea3fc429284c2