### PR TITLE
Add Spanish translations and set default locale

### DIFF
--- a/app/[locale]/login/page.tsx
+++ b/app/[locale]/login/page.tsx
@@ -2,6 +2,7 @@ import { Brand } from "@/components/ui/brand"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { SubmitButton } from "@/components/ui/submit-button"
+import initTranslations from "@/lib/i18n"
 import { createClient } from "@/lib/supabase/server"
 import { Database } from "@/supabase/types"
 import { createServerClient } from "@supabase/ssr"
@@ -15,8 +16,10 @@ export const metadata: Metadata = {
 }
 
 export default async function Login({
+  params: { locale },
   searchParams
 }: {
+  params: { locale: string }
   searchParams: { message: string }
 }) {
   const cookieStore = cookies()
@@ -47,6 +50,8 @@ export default async function Login({
 
     return redirect(`/${homeWorkspace.id}/chat`)
   }
+
+  const { t } = await initTranslations(locale, ["translation"])
 
   const signIn = async (formData: FormData) => {
     "use server"
@@ -170,17 +175,17 @@ export default async function Login({
         <Brand />
 
         <Label className="text-md mt-4" htmlFor="email">
-          Email
+          {t("Email")}
         </Label>
         <Input
           className="mb-3 rounded-md border bg-inherit px-4 py-2"
           name="email"
-          placeholder="you@example.com"
+          placeholder={t("you@example.com")}
           required
         />
 
         <Label className="text-md" htmlFor="password">
-          Password
+          {t("Password")}
         </Label>
         <Input
           className="mb-6 rounded-md border bg-inherit px-4 py-2"
@@ -190,23 +195,23 @@ export default async function Login({
         />
 
         <SubmitButton className="mb-2 rounded-md bg-blue-700 px-4 py-2 text-white">
-          Login
+          {t("Login")}
         </SubmitButton>
 
         <SubmitButton
           formAction={signUp}
           className="border-foreground/20 mb-2 rounded-md border px-4 py-2"
         >
-          Sign Up
+          {t("Sign Up")}
         </SubmitButton>
 
         <div className="text-muted-foreground mt-1 flex justify-center text-sm">
-          <span className="mr-1">Forgot your password?</span>
+          <span className="mr-1">{t("Forgot your password?")}</span>
           <button
             formAction={handleResetPassword}
             className="text-primary ml-1 underline hover:opacity-80"
           >
-            Reset
+            {t("Reset")}
           </button>
         </div>
 

--- a/components/chat/quick-settings.tsx
+++ b/components/chat/quick-settings.tsx
@@ -217,7 +217,7 @@ export const QuickSettings: FC<QuickSettingsProps> = ({}) => {
             ))}
 
           {loading ? (
-            <div className="animate-pulse">Loading assistant...</div>
+            <div className="animate-pulse">{t("Loading assistant...")}</div>
           ) : (
             <>
               <div className="overflow-hidden text-ellipsis">
@@ -241,13 +241,13 @@ export const QuickSettings: FC<QuickSettingsProps> = ({}) => {
         align="start"
       >
         {presets.length === 0 && assistants.length === 0 ? (
-          <div className="p-8 text-center">No items found.</div>
+          <div className="p-8 text-center">{t("No items found.")}</div>
         ) : (
           <>
             <Input
               ref={inputRef}
               className="w-full"
-              placeholder="Search..."
+              placeholder={t("Search...")}
               value={search}
               onChange={e => setSearch(e.target.value)}
               onKeyDown={e => e.stopPropagation()}

--- a/i18nConfig.js
+++ b/i18nConfig.js
@@ -1,5 +1,5 @@
 const i18nConfig = {
-  defaultLocale: "en",
+  defaultLocale: "es",
   locales: [
     "ar",
     "bn",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -1,4 +1,14 @@
 {
   "Ask anything. Type \"/\" for prompts, \"@\" for files, and \"#\" for tools.": "Ask anything. Type \"/\" for prompts, \"@\" for files, and \"#\" for tools.",
-  "Quick Settings": "Quick Settings"
+  "Quick Settings": "Quick Settings",
+  "Loading assistant...": "Loading assistant...",
+  "No items found.": "No items found.",
+  "Search...": "Search...",
+  "Email": "Email",
+  "Password": "Password",
+  "Login": "Login",
+  "Sign Up": "Sign Up",
+  "Forgot your password?": "Forgot your password?",
+  "Reset": "Reset",
+  "you@example.com": "you@example.com"
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1,3 +1,14 @@
 {
-  "Ask anything. Type \"/\" for prompts, \"@\" for files, and \"#\" for tools.": "Ask anything. Type \"/\" for prompts, \"@\" for files, and \"#\" for tools."
+  "Ask anything. Type \"/\" for prompts, \"@\" for files, and \"#\" for tools.": "Ask anything. Type \"/\" for prompts, \"@\" for files, and \"#\" for tools.",
+  "Quick Settings": "Quick Settings",
+  "Loading assistant...": "Loading assistant...",
+  "No items found.": "No items found.",
+  "Search...": "Search...",
+  "Email": "Email",
+  "Password": "Password",
+  "Login": "Login",
+  "Sign Up": "Sign Up",
+  "Forgot your password?": "Forgot your password?",
+  "Reset": "Reset",
+  "you@example.com": "you@example.com"
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1,0 +1,14 @@
+{
+  "Ask anything. Type \"/\" for prompts, \"@\" for files, and \"#\" for tools.": "Pregunta lo que quieras. Escribe \"/\" para indicaciones, \"@\" para archivos y \"#\" para herramientas.",
+  "Quick Settings": "Ajustes rápidos",
+  "Loading assistant...": "Cargando asistente...",
+  "No items found.": "No se encontraron elementos.",
+  "Search...": "Buscar...",
+  "Email": "Correo electrónico",
+  "Password": "Contraseña",
+  "Login": "Iniciar sesión",
+  "Sign Up": "Registrarse",
+  "Forgot your password?": "¿Olvidaste tu contraseña?",
+  "Reset": "Restablecer",
+  "you@example.com": "tucorreo@ejemplo.com"
+}


### PR DESCRIPTION
## Summary
- translate Login page text via i18next
- translate Quick Settings labels
- add Spanish `translation.json`
- extend English and German translations
- set default locale to Spanish

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run format:write`

------
https://chatgpt.com/codex/tasks/task_e_687262471af8832fae0f9215b324c023